### PR TITLE
Fix useToast listener effect

### DIFF
--- a/frontend/src/hooks/use-toast.ts
+++ b/frontend/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- remove state from the `useToast` effect dependency array to avoid multiple listener registrations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*